### PR TITLE
feat(ui): US-014 help overlay with keybinding reference

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/charmbracelet/bubbles/list"
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
 	"github.com/Nathan-ma/hubstaff-tui/internal/config"
@@ -44,6 +45,10 @@ type AppModel struct {
 	timerStart time.Time     // when we started ticking
 	tracking   bool
 
+	// Help overlay
+	showHelp bool
+	help     HelpModel
+
 	// Error/status messages
 	statusMsg string
 	statusErr bool
@@ -59,6 +64,7 @@ func NewApp(cfg config.Config, client *api.Client) AppModel {
 		current:  screenProjects,
 		projects: NewProjectsModel(theme),
 		tasks:    NewTasksModel(theme),
+		help:     NewHelpModel(theme),
 	}
 }
 
@@ -86,14 +92,37 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.projects.SetSize(m.width, contentHeight)
 		m.tasks.SetSize(m.width, contentHeight)
+		if m.showHelp {
+			m.help.SetSize(m.width, m.height)
+		}
 		return m, nil
 
 	case tea.KeyMsg:
+		// When help overlay is visible, only handle dismiss keys and scrolling
+		if m.showHelp {
+			switch msg.String() {
+			case "?", "esc":
+				m.showHelp = false
+				return m, nil
+			case "ctrl+c":
+				return m, tea.Quit
+			default:
+				// Route to viewport for scrolling (j/k/up/down/pgup/pgdown)
+				var cmd tea.Cmd
+				m.help, cmd = m.help.Update(msg)
+				return m, cmd
+			}
+		}
+
 		// Handle global keys first, but only when not filtering
 		if !m.isFiltering() {
 			switch msg.String() {
 			case "ctrl+c":
 				return m, tea.Quit
+			case "?":
+				m.showHelp = true
+				m.help.SetSize(m.width, m.height)
+				return m, nil
 			case "ctrl+e":
 				return m, m.stopTracking()
 			case "ctrl+r":
@@ -248,7 +277,15 @@ func (m AppModel) View() string {
 		content = m.tasks.View()
 	}
 
-	return header + "\n" + content + "\n" + footer
+	view := header + "\n" + content + "\n" + footer
+
+	if m.showHelp {
+		helpBox := m.help.View()
+		overlay := lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, helpBox)
+		return overlay
+	}
+
+	return view
 }
 
 // --- Commands ---

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -19,12 +19,14 @@ func (m AppModel) footerView() string {
 			m.keyHint("ctrl+e", "stop") + "  " +
 			m.keyHint("ctrl+r", "refresh") + "  " +
 			m.keyHint("/", "filter") + "  " +
+			m.keyHint("?", "help") + "  " +
 			m.keyHint("esc", "quit")
 	case screenTasks:
 		hints = m.keyHint("enter", "start") + "  " +
 			m.keyHint("ctrl+e", "stop") + "  " +
 			m.keyHint("ctrl+r", "refresh") + "  " +
 			m.keyHint("/", "filter") + "  " +
+			m.keyHint("?", "help") + "  " +
 			m.keyHint("esc", "back")
 	}
 

--- a/internal/ui/help.go
+++ b/internal/ui/help.go
@@ -1,0 +1,195 @@
+package ui
+
+import (
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// HelpModel is a modal overlay that displays all keybindings.
+type HelpModel struct {
+	viewport viewport.Model
+	theme    Theme
+	width    int
+	height   int
+}
+
+// NewHelpModel creates a new HelpModel with default dimensions.
+func NewHelpModel(theme Theme) HelpModel {
+	vp := viewport.New(0, 0)
+	return HelpModel{
+		viewport: vp,
+		theme:    theme,
+	}
+}
+
+// SetSize updates the help overlay dimensions based on terminal size.
+// The overlay occupies at most 60 columns and 80% of the terminal height.
+func (m *HelpModel) SetSize(termWidth, termHeight int) {
+	m.width = termWidth
+	m.height = termHeight
+
+	boxWidth := 60
+	if termWidth-4 < boxWidth {
+		boxWidth = termWidth - 4
+	}
+	if boxWidth < 20 {
+		boxWidth = 20
+	}
+
+	// Content width inside the border (border takes 2 cols)
+	contentWidth := boxWidth - 2
+
+	// Build the help text content
+	content := m.helpContent(contentWidth)
+
+	// Calculate how tall the viewport needs to be.
+	// Reserve 2 lines for the border top/bottom.
+	contentLines := strings.Count(content, "\n") + 1
+	maxVPHeight := termHeight - 6 // leave room for border + margins
+	if maxVPHeight < 5 {
+		maxVPHeight = 5
+	}
+	vpHeight := contentLines
+	if vpHeight > maxVPHeight {
+		vpHeight = maxVPHeight
+	}
+
+	m.viewport.Width = contentWidth
+	m.viewport.Height = vpHeight
+	m.viewport.SetContent(content)
+}
+
+// Update handles input for the help viewport (scrolling).
+func (m HelpModel) Update(msg tea.Msg) (HelpModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the help overlay as a bordered, centered box.
+func (m HelpModel) View() string {
+	titleStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(m.theme.HeaderTitle.GetForeground()).
+		Padding(0, 1)
+
+	title := titleStyle.Render("Keybindings")
+
+	boxStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(m.theme.ActiveBorder.GetBorderTopForeground()).
+		Padding(1, 2)
+
+	content := m.viewport.View()
+
+	// Show scroll hint if content is scrollable
+	if m.viewport.TotalLineCount() > m.viewport.Height {
+		scrollHint := m.theme.FooterDesc.Render("  scroll: j/k  ")
+		content += "\n" + scrollHint
+	}
+
+	box := boxStyle.Render(content)
+
+	// Place the title on the top border
+	boxLines := strings.Split(box, "\n")
+	if len(boxLines) > 0 {
+		// Insert title into the top border line
+		borderLine := boxLines[0]
+		titleStr := title
+		titleWidth := lipgloss.Width(titleStr)
+		borderWidth := lipgloss.Width(borderLine)
+		if titleWidth+4 < borderWidth {
+			// Replace part of the border with the title
+			// The border line starts with the corner character
+			runes := []rune(borderLine)
+			titleRunes := []rune(titleStr)
+			insertAt := 2 // after corner + one border char
+			if insertAt+len(titleRunes) < len(runes) {
+				for i, r := range titleRunes {
+					runes[insertAt+i] = r
+				}
+				boxLines[0] = string(runes)
+			}
+		}
+		box = strings.Join(boxLines, "\n")
+	}
+
+	return box
+}
+
+// helpContent builds the formatted help text.
+func (m HelpModel) helpContent(width int) string {
+	sectionStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(m.theme.HeaderTitle.GetForeground())
+
+	keyStyle := lipgloss.NewStyle().
+		Bold(true).
+		Foreground(m.theme.FooterKey.GetForeground()).
+		Width(14).
+		Align(lipgloss.Left)
+
+	descStyle := lipgloss.NewStyle().
+		Foreground(m.theme.FooterDesc.GetForeground())
+
+	_ = width
+
+	var b strings.Builder
+
+	sections := []struct {
+		title string
+		keys  []struct{ key, desc string }
+	}{
+		{
+			title: "Navigation",
+			keys: []struct{ key, desc string }{
+				{"Enter", "Select project / Start task"},
+				{"Esc", "Back / Quit"},
+				{"Ctrl+P", "Back to projects"},
+				{"j / k", "Navigate list"},
+				{"/ (slash)", "Fuzzy filter"},
+				{"Esc", "Clear filter"},
+			},
+		},
+		{
+			title: "Tracking",
+			keys: []struct{ key, desc string }{
+				{"Enter", "Start tracking selected task"},
+				{"Ctrl+E", "Stop tracking"},
+			},
+		},
+		{
+			title: "Views",
+			keys: []struct{ key, desc string }{
+				{"T", "Today's summary"},
+				{"?", "Toggle this help"},
+				{"Ctrl+R", "Refresh (clear cache)"},
+			},
+		},
+		{
+			title: "General",
+			keys: []struct{ key, desc string }{
+				{"Ctrl+C", "Force quit"},
+			},
+		},
+	}
+
+	for i, section := range sections {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(sectionStyle.Render(section.title))
+		b.WriteString("\n")
+		for _, kv := range section.keys {
+			b.WriteString("  ")
+			b.WriteString(keyStyle.Render(kv.key))
+			b.WriteString(descStyle.Render(kv.desc))
+			b.WriteString("\n")
+		}
+	}
+
+	return strings.TrimRight(b.String(), "\n")
+}

--- a/internal/ui/help_test.go
+++ b/internal/ui/help_test.go
@@ -1,0 +1,121 @@
+package ui
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewHelpModel(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+
+	if h.viewport.Width != 0 {
+		t.Errorf("expected initial viewport width 0, got %d", h.viewport.Width)
+	}
+	if h.viewport.Height != 0 {
+		t.Errorf("expected initial viewport height 0, got %d", h.viewport.Height)
+	}
+}
+
+func TestHelpModel_SetSize(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+	h.SetSize(80, 40)
+
+	if h.width != 80 {
+		t.Errorf("expected width 80, got %d", h.width)
+	}
+	if h.height != 40 {
+		t.Errorf("expected height 40, got %d", h.height)
+	}
+	if h.viewport.Width == 0 {
+		t.Error("viewport width should be non-zero after SetSize")
+	}
+	if h.viewport.Height == 0 {
+		t.Error("viewport height should be non-zero after SetSize")
+	}
+}
+
+func TestHelpModel_SetSize_NarrowTerminal(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+	h.SetSize(30, 20)
+
+	// Should still have reasonable dimensions
+	if h.viewport.Width < 18 {
+		t.Errorf("viewport width too small: %d", h.viewport.Width)
+	}
+}
+
+func TestHelpModel_View_ContainsKeybindings(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+	h.SetSize(80, 40)
+
+	view := h.View()
+
+	expectedSections := []string{
+		"Navigation",
+		"Tracking",
+		"Views",
+		"General",
+	}
+	for _, section := range expectedSections {
+		if !strings.Contains(view, section) {
+			t.Errorf("help view missing section %q", section)
+		}
+	}
+
+	expectedKeys := []string{
+		"Enter",
+		"Esc",
+		"Ctrl+E",
+		"Ctrl+R",
+		"Ctrl+C",
+	}
+	for _, key := range expectedKeys {
+		if !strings.Contains(view, key) {
+			t.Errorf("help view missing key %q", key)
+		}
+	}
+}
+
+func TestHelpModel_View_ContainsTitle(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+	h.SetSize(80, 40)
+
+	view := h.View()
+	if !strings.Contains(view, "Keybindings") {
+		t.Error("help view should contain 'Keybindings' title")
+	}
+}
+
+func TestHelpContent_AllSections(t *testing.T) {
+	theme := CatppuccinMocha()
+	h := NewHelpModel(theme)
+	content := h.helpContent(56)
+
+	// Should have all four sections
+	for _, section := range []string{"Navigation", "Tracking", "Views", "General"} {
+		if !strings.Contains(content, section) {
+			t.Errorf("helpContent missing section %q", section)
+		}
+	}
+
+	// Should have descriptions
+	descriptions := []string{
+		"Select project",
+		"Back / Quit",
+		"Stop tracking",
+		"Toggle this help",
+		"Force quit",
+		"Fuzzy filter",
+		"Refresh",
+	}
+	for _, desc := range descriptions {
+		if !strings.Contains(content, desc) {
+			t.Errorf("helpContent missing description %q", desc)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- `?` key toggles a centered modal overlay showing all keybindings
- Keybindings grouped by context: Navigation, Tracking, Views, General
- Scrollable via viewport when content exceeds terminal height
- `?` or `Esc` dismisses the overlay
- Footer updated with `?:help` hint
- Includes unit tests for help model


Closes #14

## Test plan
- [ ] Press `?` on projects screen — overlay appears centered
- [ ] Press `?` again or `Esc` — overlay dismisses
- [ ] Overlay is scrollable on small terminals
- [ ] All keybinding groups display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)