### PR TITLE
feat(ui): US-011 today's summary view with SQLite sessions

### DIFF
--- a/cmd/hubstaff-tui/main.go
+++ b/cmd/hubstaff-tui/main.go
@@ -3,11 +3,13 @@ package main
 import (
 	"fmt"
 	"os"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
 	"github.com/Nathan-ma/hubstaff-tui/internal/config"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 	"github.com/Nathan-ma/hubstaff-tui/internal/ui"
 )
 
@@ -47,7 +49,21 @@ func main() {
 
 	client := api.NewClient(cfg.Hubstaff.CLIPath)
 
-	model := ui.NewApp(cfg, client)
+	// Open local store for session tracking and summaries
+	dbPath, err := cfg.ResolvedDBPath()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error resolving DB path: %v\n", err)
+		os.Exit(1)
+	}
+	ttl := time.Duration(cfg.Store.TTLSeconds) * time.Second
+	st, err := store.Open(dbPath, ttl)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error opening store: %v\n", err)
+		os.Exit(1)
+	}
+	defer st.Close()
+
+	model := ui.NewApp(cfg, client, st)
 	p := tea.NewProgram(model, tea.WithAltScreen())
 	if _, err := p.Run(); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)

--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
 	"github.com/Nathan-ma/hubstaff-tui/internal/config"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 )
 
 type screen int
@@ -19,12 +20,14 @@ type screen int
 const (
 	screenProjects screen = iota
 	screenTasks
+	screenSummary
 )
 
 // AppModel is the root Bubbletea model for the TUI.
 type AppModel struct {
 	cfg    config.Config
 	client *api.Client
+	store  *store.Store
 	theme  Theme
 
 	// Navigation
@@ -33,6 +36,7 @@ type AppModel struct {
 	// Sub-models
 	projects ProjectsModel
 	tasks    TasksModel
+	summary  SummaryModel
 
 	// Global state
 	status api.Status
@@ -50,15 +54,17 @@ type AppModel struct {
 }
 
 // NewApp creates a new AppModel ready for tea.NewProgram.
-func NewApp(cfg config.Config, client *api.Client) AppModel {
+func NewApp(cfg config.Config, client *api.Client, st *store.Store) AppModel {
 	theme := GetTheme(cfg.UI.Theme)
 	return AppModel{
 		cfg:      cfg,
 		client:   client,
+		store:    st,
 		theme:    theme,
 		current:  screenProjects,
 		projects: NewProjectsModel(theme),
 		tasks:    NewTasksModel(theme),
+		summary:  NewSummaryModel(theme),
 	}
 }
 
@@ -86,6 +92,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		m.projects.SetSize(m.width, contentHeight)
 		m.tasks.SetSize(m.width, contentHeight)
+		m.summary.SetSize(m.width, contentHeight)
 		return m, nil
 
 	case tea.KeyMsg:
@@ -101,6 +108,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.statusMsg = "Refreshing..."
 				m.statusErr = false
 				return m, tea.Batch(cmds...)
+			case "T":
+				if m.current != screenSummary {
+					m.current = screenSummary
+					m.summary.SetSize(m.width, m.height-2) // header + footer
+					return m, m.fetchSummary()
+				}
 			}
 		}
 
@@ -125,6 +138,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 						return m, m.startTask(t.ID, m.tasks.projectID)
 					}
 				case "esc":
+					m.current = screenProjects
+					return m, nil
+				}
+			case screenSummary:
+				switch msg.String() {
+				case "esc", "T":
 					m.current = screenProjects
 					return m, nil
 				}
@@ -206,6 +225,17 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, tea.Batch(cmds...)
 
+	case summaryMsg:
+		m.summary.SetRows(msg.rows)
+		return m, nil
+
+	case summaryErrMsg:
+		m.statusMsg = fmt.Sprintf("Summary error: %v", msg.err)
+		m.statusErr = true
+		m.current = screenProjects
+		cmds = append(cmds, m.clearStatusAfter(3*time.Second))
+		return m, tea.Batch(cmds...)
+
 	case clearStatusMsg:
 		m.statusMsg = ""
 		m.statusErr = false
@@ -223,6 +253,12 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case screenTasks:
 		var cmd tea.Cmd
 		m.tasks, cmd = m.tasks.Update(msg)
+		if cmd != nil {
+			cmds = append(cmds, cmd)
+		}
+	case screenSummary:
+		var cmd tea.Cmd
+		m.summary, cmd = m.summary.Update(msg)
 		if cmd != nil {
 			cmds = append(cmds, cmd)
 		}
@@ -246,6 +282,8 @@ func (m AppModel) View() string {
 		content = m.projects.View()
 	case screenTasks:
 		content = m.tasks.View()
+	case screenSummary:
+		content = m.summary.View()
 	}
 
 	return header + "\n" + content + "\n" + footer
@@ -283,6 +321,20 @@ func (m AppModel) fetchTasks(projectID string) tea.Cmd {
 			return tasksErrMsg{err: err}
 		}
 		return tasksMsg{tasks: tasks}
+	}
+}
+
+func (m AppModel) fetchSummary() tea.Cmd {
+	st := m.store
+	return func() tea.Msg {
+		if st == nil {
+			return summaryErrMsg{err: fmt.Errorf("store not configured")}
+		}
+		rows, err := st.TodaySummary()
+		if err != nil {
+			return summaryErrMsg{err: err}
+		}
+		return summaryMsg{rows: rows}
 	}
 }
 
@@ -330,6 +382,8 @@ func (m AppModel) isFiltering() bool {
 		return m.projects.list.FilterState() == list.Filtering
 	case screenTasks:
 		return m.tasks.list.FilterState() == list.Filtering
+	case screenSummary:
+		return false
 	}
 	return false
 }

--- a/internal/ui/footer.go
+++ b/internal/ui/footer.go
@@ -19,12 +19,18 @@ func (m AppModel) footerView() string {
 			m.keyHint("ctrl+e", "stop") + "  " +
 			m.keyHint("ctrl+r", "refresh") + "  " +
 			m.keyHint("/", "filter") + "  " +
+			m.keyHint("T", "summary") + "  " +
 			m.keyHint("esc", "quit")
 	case screenTasks:
 		hints = m.keyHint("enter", "start") + "  " +
 			m.keyHint("ctrl+e", "stop") + "  " +
 			m.keyHint("ctrl+r", "refresh") + "  " +
 			m.keyHint("/", "filter") + "  " +
+			m.keyHint("T", "summary") + "  " +
+			m.keyHint("esc", "back")
+	case screenSummary:
+		hints = m.keyHint("j/k", "scroll") + "  " +
+			m.keyHint("T", "back") + "  " +
 			m.keyHint("esc", "back")
 	}
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 )
 
 // Messages used to communicate between async commands and the TUI.
@@ -24,3 +25,6 @@ type stopErrMsg struct{ err error }
 type tickMsg struct{}
 
 type clearStatusMsg struct{}
+
+type summaryMsg struct{ rows []store.SummaryRow }
+type summaryErrMsg struct{ err error }

--- a/internal/ui/summary.go
+++ b/internal/ui/summary.go
@@ -1,0 +1,236 @@
+package ui
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
+)
+
+// SummaryModel renders a scrollable table of today's tracked time by project/task.
+type SummaryModel struct {
+	viewport viewport.Model
+	rows     []store.SummaryRow
+	theme    Theme
+	width    int
+	height   int
+	ready    bool
+}
+
+// NewSummaryModel creates an empty SummaryModel.
+func NewSummaryModel(theme Theme) SummaryModel {
+	return SummaryModel{
+		theme: theme,
+	}
+}
+
+// SetSize updates the viewport dimensions.
+func (m *SummaryModel) SetSize(w, h int) {
+	m.width = w
+	m.height = h
+	if m.ready {
+		m.viewport.Width = w
+		m.viewport.Height = h
+	}
+}
+
+// SetRows populates the summary data and rebuilds the viewport content.
+func (m *SummaryModel) SetRows(rows []store.SummaryRow) {
+	m.rows = rows
+	if !m.ready {
+		m.viewport = viewport.New(m.width, m.height)
+		m.viewport.Style = lipgloss.NewStyle()
+		m.ready = true
+	}
+	m.viewport.SetContent(m.renderTable())
+	m.viewport.GotoTop()
+}
+
+// Update handles viewport scrolling keys.
+func (m SummaryModel) Update(msg tea.Msg) (SummaryModel, tea.Cmd) {
+	if !m.ready {
+		return m, nil
+	}
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+// View renders the summary viewport.
+func (m SummaryModel) View() string {
+	if !m.ready {
+		return "Loading summary..."
+	}
+	return m.viewport.View()
+}
+
+// renderTable builds the table string from the summary rows.
+func (m SummaryModel) renderTable() string {
+	if len(m.rows) == 0 {
+		return m.theme.DimmedItem.Render("No time tracked today")
+	}
+
+	// Determine column widths
+	projHeader := "Project"
+	taskHeader := "Task"
+	durHeader := "Duration"
+
+	maxProj := len(projHeader)
+	maxTask := len(taskHeader)
+	maxDur := len(durHeader)
+
+	type rendered struct {
+		proj string
+		task string
+		dur  string
+	}
+	var lines []rendered
+	var totalSeconds int
+
+	for _, r := range m.rows {
+		proj := r.ProjectName
+		if proj == "" {
+			proj = r.ProjectID
+		}
+		task := r.TaskSummary
+		if task == "" {
+			task = r.TaskID
+		}
+		dur := formatCompactDuration(r.DurationSeconds)
+		totalSeconds += r.DurationSeconds
+
+		if len(proj) > maxProj {
+			maxProj = len(proj)
+		}
+		if len(task) > maxTask {
+			maxTask = len(task)
+		}
+		if len(dur) > maxDur {
+			maxDur = len(dur)
+		}
+		lines = append(lines, rendered{proj: proj, task: task, dur: dur})
+	}
+
+	totalDur := formatCompactDuration(totalSeconds)
+	if len(totalDur) > maxDur {
+		maxDur = len(totalDur)
+	}
+
+	// Cap column widths to fit terminal, leaving room for separators
+	availWidth := m.width - 6 // 3 columns, 2 separators of " | " (each 3 chars)
+	if availWidth < 20 {
+		availWidth = 20
+	}
+	// Allocate: duration gets its width, rest split between project and task
+	remaining := availWidth - maxDur
+	if remaining < 10 {
+		remaining = 10
+	}
+	if maxProj+maxTask > remaining {
+		half := remaining / 2
+		if maxProj > half && maxTask > half {
+			maxProj = half
+			maxTask = remaining - half
+		} else if maxProj > half {
+			maxProj = remaining - maxTask
+		} else {
+			maxTask = remaining - maxProj
+		}
+	}
+
+	var sb strings.Builder
+
+	// Title
+	title := m.theme.HeaderTitle.Render("Today's Summary")
+	sb.WriteString(title)
+	sb.WriteString("\n\n")
+
+	// Header row
+	headerStyle := m.theme.FooterKey
+	sep := m.theme.Separator.Render(" | ")
+
+	hdr := headerStyle.Render(padRight(projHeader, maxProj)) + sep +
+		headerStyle.Render(padRight(taskHeader, maxTask)) + sep +
+		headerStyle.Render(padLeft(durHeader, maxDur))
+	sb.WriteString(hdr)
+	sb.WriteString("\n")
+
+	// Separator line
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxProj)))
+	sb.WriteString(m.theme.Separator.Render("─┼─"))
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxTask)))
+	sb.WriteString(m.theme.Separator.Render("─┼─"))
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxDur)))
+	sb.WriteString("\n")
+
+	// Data rows
+	for _, l := range lines {
+		row := m.theme.NormalItem.Render(padRight(truncate(l.proj, maxProj), maxProj)) + sep +
+			m.theme.NormalItem.Render(padRight(truncate(l.task, maxTask), maxTask)) + sep +
+			m.theme.TimerText.Render(padLeft(l.dur, maxDur))
+		sb.WriteString(row)
+		sb.WriteString("\n")
+	}
+
+	// Totals separator
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxProj)))
+	sb.WriteString(m.theme.Separator.Render("─┼─"))
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxTask)))
+	sb.WriteString(m.theme.Separator.Render("─┼─"))
+	sb.WriteString(m.theme.Separator.Render(strings.Repeat("─", maxDur)))
+	sb.WriteString("\n")
+
+	// Total row
+	totalLabel := "Total"
+	totalRow := headerStyle.Render(padRight(totalLabel, maxProj)) + sep +
+		m.theme.NormalItem.Render(padRight("", maxTask)) + sep +
+		m.theme.TimerText.Render(padLeft(totalDur, maxDur))
+	sb.WriteString(totalRow)
+	sb.WriteString("\n")
+
+	return sb.String()
+}
+
+// formatCompactDuration formats seconds as "Xh YYm" for compact display.
+func formatCompactDuration(seconds int) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	h := seconds / 3600
+	m := (seconds % 3600) / 60
+	if h > 0 {
+		return fmt.Sprintf("%dh %02dm", h, m)
+	}
+	return fmt.Sprintf("%dm", m)
+}
+
+// padRight pads a string with spaces on the right to reach width.
+func padRight(s string, width int) string {
+	if len(s) >= width {
+		return s[:width]
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}
+
+// padLeft pads a string with spaces on the left to reach width.
+func padLeft(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return strings.Repeat(" ", width-len(s)) + s
+}
+
+// truncate shortens a string to maxLen, appending "…" if truncated.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	if maxLen <= 1 {
+		return s[:maxLen]
+	}
+	return s[:maxLen-1] + "…"
+}


### PR DESCRIPTION
## Summary
- `T` key toggles a full-screen summary view showing time tracked today
- Table format: Project | Task | Duration, sorted by project then task
- Totals row at the bottom with total time
- Empty state: "No time tracked today"
- Scrollable via viewport for long lists
- Store integrated into AppModel; main.go opens SQLite on startup
- Updated NewApp signature to accept *store.Store


Closes #20

## Test plan
- [ ] Press `T` on projects screen — summary view appears
- [ ] Summary shows correct project/task/duration data
- [ ] Press `T` or `Esc` — returns to browser
- [ ] Empty day shows "No time tracked today"
- [ ] Viewport scrolls with j/k on long lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)