### PR TITLE
feat(ui): US-010 recent tasks shortlist with SQLite recents

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
 	"github.com/Nathan-ma/hubstaff-tui/internal/config"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 )
 
 type screen int
@@ -25,6 +26,7 @@ const (
 type AppModel struct {
 	cfg    config.Config
 	client *api.Client
+	store  *store.Store
 	theme  Theme
 
 	// Navigation
@@ -50,11 +52,12 @@ type AppModel struct {
 }
 
 // NewApp creates a new AppModel ready for tea.NewProgram.
-func NewApp(cfg config.Config, client *api.Client) AppModel {
+func NewApp(cfg config.Config, client *api.Client, s *store.Store) AppModel {
 	theme := GetTheme(cfg.UI.Theme)
 	return AppModel{
 		cfg:      cfg,
 		client:   client,
+		store:    s,
 		theme:    theme,
 		current:  screenProjects,
 		projects: NewProjectsModel(theme),
@@ -113,7 +116,7 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					if p, ok := m.projects.SelectedProject(); ok {
 						m.current = screenTasks
 						m.tasks.SetProject(p.ID, p.Name)
-						return m, tea.Batch(m.fetchTasks(p.ID), m.tasks.spinner.Tick)
+						return m, tea.Batch(m.fetchTasks(p.ID), m.fetchRecents(), m.tasks.spinner.Tick)
 					}
 				case "esc":
 					return m, tea.Quit
@@ -168,6 +171,17 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.tasks.SetTasks(msg.tasks, m.status)
 		return m, nil
 
+	case recentsMsg:
+		m.tasks.SetRecents([]store.RecentRow(msg))
+		return m, nil
+
+	case recentsErrMsg:
+		// Non-critical: just log to status briefly.
+		m.statusMsg = fmt.Sprintf("Recents error: %v", msg.err)
+		m.statusErr = true
+		cmds = append(cmds, m.clearStatusAfter(3*time.Second))
+		return m, tea.Batch(cmds...)
+
 	case tasksErrMsg:
 		m.tasks.loading = false
 		m.statusMsg = fmt.Sprintf("Tasks error: %v", msg.err)
@@ -178,6 +192,9 @@ func (m AppModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case startedMsg:
 		m.statusMsg = "Tracking started"
 		m.statusErr = false
+		if m.store != nil {
+			_ = m.store.TouchRecent(msg.taskID, msg.projectID)
+		}
 		cmds = append(cmds, m.fetchStatus(), m.clearStatusAfter())
 		return m, tea.Batch(cmds...)
 
@@ -288,13 +305,27 @@ func (m AppModel) fetchTasks(projectID string) tea.Cmd {
 
 func (m AppModel) startTask(taskID, projectID string) tea.Cmd {
 	client := m.client
-	_ = projectID // reserved for future use (e.g., session tracking)
 	return func() tea.Msg {
 		err := client.StartTask(context.Background(), taskID)
 		if err != nil {
 			return startErrMsg{err: err}
 		}
-		return startedMsg{}
+		return startedMsg{taskID: taskID, projectID: projectID}
+	}
+}
+
+func (m AppModel) fetchRecents() tea.Cmd {
+	s := m.store
+	limit := m.cfg.RecentTasks.MaxItems
+	return func() tea.Msg {
+		if s == nil {
+			return recentsMsg(nil)
+		}
+		recents, err := s.ListRecents(limit)
+		if err != nil {
+			return recentsErrMsg{err: err}
+		}
+		return recentsMsg(recents)
 	}
 }
 

--- a/internal/ui/messages.go
+++ b/internal/ui/messages.go
@@ -2,6 +2,7 @@ package ui
 
 import (
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 )
 
 // Messages used to communicate between async commands and the TUI.
@@ -15,7 +16,10 @@ type projectsErrMsg struct{ err error }
 type tasksMsg struct{ tasks []api.Task }
 type tasksErrMsg struct{ err error }
 
-type startedMsg struct{}
+type startedMsg struct {
+	taskID    string
+	projectID string
+}
 type startErrMsg struct{ err error }
 
 type stoppedMsg struct{}
@@ -24,3 +28,6 @@ type stopErrMsg struct{ err error }
 type tickMsg struct{}
 
 type clearStatusMsg struct{}
+
+type recentsMsg []store.RecentRow
+type recentsErrMsg struct{ err error }

--- a/internal/ui/tasks.go
+++ b/internal/ui/tasks.go
@@ -10,6 +10,7 @@ import (
 	"github.com/charmbracelet/x/ansi"
 
 	"github.com/Nathan-ma/hubstaff-tui/internal/api"
+	"github.com/Nathan-ma/hubstaff-tui/internal/store"
 )
 
 // taskItem wraps an api.Task for use in a bubbles/list.
@@ -17,16 +18,27 @@ type taskItem struct {
 	task     api.Task
 	tracking bool // currently being tracked
 	active   bool // was the last tracked task
+	recent   bool // recently used
 }
 
 func (i taskItem) Title() string       { return i.task.Summary }
 func (i taskItem) Description() string { return "" }
 func (i taskItem) FilterValue() string { return i.task.Summary }
 
+// separatorItem is a non-selectable visual separator in the task list.
+type separatorItem struct {
+	label string
+}
+
+func (s separatorItem) Title() string       { return s.label }
+func (s separatorItem) Description() string { return "" }
+func (s separatorItem) FilterValue() string { return "" }
+
 // TasksModel holds the state for the tasks list screen.
 type TasksModel struct {
 	list        list.Model
 	tasks       []api.Task
+	recents     []store.RecentRow
 	projectID   string
 	projectName string
 	status      api.Status
@@ -45,6 +57,13 @@ func (d taskDelegate) Spacing() int                            { return 0 }
 func (d taskDelegate) Update(_ tea.Msg, _ *list.Model) tea.Cmd { return nil }
 
 func (d taskDelegate) Render(w io.Writer, m list.Model, index int, item list.Item) {
+	// Handle separator items
+	if sep, ok := item.(separatorItem); ok {
+		line := d.theme.Separator.Render(sep.label)
+		fmt.Fprint(w, line)
+		return
+	}
+
 	ti, ok := item.(taskItem)
 	if !ok {
 		return
@@ -55,16 +74,25 @@ func (d taskDelegate) Render(w io.Writer, m list.Model, index int, item list.Ite
 	name := ti.task.Summary
 	isSelected := index == m.Index()
 
+	recentLabel := ""
+	if ti.recent {
+		recentLabel = " " + d.theme.DimmedItem.Render("recent")
+	}
+
 	maxWidth := m.Width() - 4
+	if ti.recent && maxWidth > 0 {
+		// Leave room for the "recent" label (about 8 chars with styling)
+		maxWidth -= 8
+	}
 	if maxWidth > 0 {
 		name = ansi.Truncate(name, maxWidth, "...")
 	}
 
 	var line string
 	if isSelected {
-		line = d.theme.SelectedItem.Render(fmt.Sprintf("%s %s", indicator, name))
+		line = d.theme.SelectedItem.Render(fmt.Sprintf("%s %s", indicator, name)) + recentLabel
 	} else {
-		line = d.theme.NormalItem.Render(fmt.Sprintf("%s %s", indicator, name))
+		line = d.theme.NormalItem.Render(fmt.Sprintf("%s %s", indicator, name)) + recentLabel
 	}
 
 	_, _ = fmt.Fprint(w, line)
@@ -110,25 +138,96 @@ func (m *TasksModel) SetProject(projectID, projectName string) {
 }
 
 // SetTasks updates the task list items, marking tracking state.
+// It rebuilds the list incorporating any previously loaded recents.
 func (m *TasksModel) SetTasks(tasks []api.Task, status api.Status) {
 	m.tasks = tasks
 	m.status = status
 	m.loading = false
+	m.rebuildList()
+}
 
-	items := make([]list.Item, len(tasks))
-	for i, t := range tasks {
-		tracking := status.Tracking && status.ActiveTask.ID == t.ID
-		active := !status.Tracking && status.ActiveTask.ID == t.ID && status.ActiveTask.ID != ""
-		items[i] = taskItem{
+// SetRecents updates the recents list and rebuilds the task list display.
+func (m *TasksModel) SetRecents(recents []store.RecentRow) {
+	m.recents = recents
+	// Only rebuild if tasks are already loaded (not still loading).
+	if !m.loading && len(m.tasks) > 0 {
+		m.rebuildList()
+	}
+}
+
+// rebuildList constructs the list items with recents shown first under a separator,
+// followed by the remaining tasks.
+func (m *TasksModel) rebuildList() {
+	// Build a set of recent task IDs for this project.
+	recentIDs := make(map[string]bool)
+	for _, r := range m.recents {
+		if r.ProjectID == m.projectID {
+			recentIDs[r.TaskID] = true
+		}
+	}
+
+	// Separate tasks into recent and non-recent groups.
+	var recentTasks, otherTasks []api.Task
+	for _, t := range m.tasks {
+		if recentIDs[t.ID] {
+			recentTasks = append(recentTasks, t)
+		} else {
+			otherTasks = append(otherTasks, t)
+		}
+	}
+
+	// Order recent tasks by their recency (order from m.recents).
+	if len(recentTasks) > 1 {
+		orderMap := make(map[string]int)
+		for i, r := range m.recents {
+			orderMap[r.TaskID] = i
+		}
+		// Simple insertion sort for small N.
+		for i := 1; i < len(recentTasks); i++ {
+			for j := i; j > 0 && orderMap[recentTasks[j].ID] < orderMap[recentTasks[j-1].ID]; j-- {
+				recentTasks[j], recentTasks[j-1] = recentTasks[j-1], recentTasks[j]
+			}
+		}
+	}
+
+	var items []list.Item
+
+	if len(recentTasks) > 0 {
+		// Add "Recent" separator
+		items = append(items, separatorItem{label: "── Recent ──"})
+
+		for _, t := range recentTasks {
+			tracking := m.status.Tracking && m.status.ActiveTask.ID == t.ID
+			active := !m.status.Tracking && m.status.ActiveTask.ID == t.ID && m.status.ActiveTask.ID != ""
+			items = append(items, taskItem{
+				task:     t,
+				tracking: tracking,
+				active:   active,
+				recent:   true,
+			})
+		}
+
+		// Add "All Tasks" separator if there are other tasks
+		if len(otherTasks) > 0 {
+			items = append(items, separatorItem{label: "── All Tasks ──"})
+		}
+	}
+
+	for _, t := range otherTasks {
+		tracking := m.status.Tracking && m.status.ActiveTask.ID == t.ID
+		active := !m.status.Tracking && m.status.ActiveTask.ID == t.ID && m.status.ActiveTask.ID != ""
+		items = append(items, taskItem{
 			task:     t,
 			tracking: tracking,
 			active:   active,
-		}
+		})
 	}
+
 	m.list.SetItems(items)
 }
 
 // SelectedTask returns the currently selected task, if any.
+// Returns false if the selection is on a separator item.
 func (m TasksModel) SelectedTask() (api.Task, bool) {
 	item := m.list.SelectedItem()
 	if item == nil {
@@ -136,6 +235,7 @@ func (m TasksModel) SelectedTask() (api.Task, bool) {
 	}
 	ti, ok := item.(taskItem)
 	if !ok {
+		// Selected item is a separator, not a task.
 		return api.Task{}, false
 	}
 	return ti.task, true


### PR DESCRIPTION
## Summary
- Recently tracked tasks appear at the top of the task list under a "-- Recent --" separator
- Recents stored in SQLite recents table via store.TouchRecent()
- On task start, the task is recorded as recently used
- Recents fetched alongside tasks when entering a project
- Configurable max items via config.recent_tasks.max_items (default 5)
- Visual separator items in the list (non-selectable)
- Recent tasks show a dimmed "recent" label


Closes #12

## Test plan
- [ ] Start a task, navigate back, re-enter project — task appears under "Recent"
- [ ] Recents ordered by most recently used
- [ ] Separator items not selectable
- [ ] Max 5 recents shown (configurable)
- [ ] Recents persist across TUI sessions (SQLite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)